### PR TITLE
Add created files to .git/info/exclude and also add --clear-files command to delete all created files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Om prosjektet
 
-`nais-env` er CLI et verktøy for å hente konfigurasjonsvariabler fra NAIS  og gjøre dem tilgjengelige lokalt. Dette forenkler lokal utvikling ved å gi deg muligheten til å jobbe med de samme miljøvariablene som finnes i Kubernetes.
+`nais-env` er CLI et verktøy for å hente konfigurasjonsvariabler fra NAIS og gjøre dem tilgjengelige lokalt. Dette forenkler lokal utvikling ved å gi deg muligheten til å jobbe med de samme miljøvariablene som finnes i Kubernetes.
 
 
 ## Funksjonalitet
@@ -11,6 +11,8 @@
 - Kan lagre disse til en fil for senere bruk
 - Kan starte et nytt shell med alle miljøvariabler satt
 - Mulighet for å skrive ut hemmelighetene direkte (når det er trygt å gjøre det)
+- Legger automatisk til genererte filer i `.git/info/exclude` for å unngå at sensitive data sjekkes inn
+- Kan rydde opp og slette alle genererte miljøfiler med `--clear-files`
 
 ## Installasjon
 
@@ -30,6 +32,9 @@ nais-env --config path/to/nais.yaml --shell
 
 # Vis alle miljøvariablene i terminalen
 nais-env --config path/to/nais.yaml --print
+
+# Slett alle miljøfiler som er opprettet av nais-env
+nais-env --clear-files
 ```
 
 ## Forutsetninger

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -66,3 +66,159 @@ pub fn parse_multiple_env_files<P: AsRef<Path>>(
 
     Ok(combined_env_vars)
 }
+
+pub fn save_env_vars_to_file(
+    filename: &str,
+    env_vars: &std::collections::BTreeMap<String, String>,
+) -> std::io::Result<()> {
+    // Convert relative path to absolute path
+    let path = std::path::Path::new(filename);
+
+    // Create file for writing
+    let mut file = std::fs::File::create(path)?;
+
+    // Write each environment variable as KEY=VALUE
+    for (key, value) in env_vars {
+        use std::io::Write;
+        writeln!(file, "{}={}", key, value)?;
+    }
+
+    // If in a git repository make sure git ignores file by adding it to .git/info/exclude
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+    {
+        if output.status.success() {
+            let git_dir = std::process::Command::new("git")
+                .args(["rev-parse", "--git-dir"])
+                .output()
+                .ok()
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|s| s.trim().to_string());
+
+            if let Some(git_dir) = git_dir {
+                let exclude_path = std::path::Path::new(&git_dir).join("info/exclude");
+                if exclude_path.exists() {
+                    let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+
+                    // Check if the file is already in the exclude file
+                    let exclude_content =
+                        std::fs::read_to_string(&exclude_path).unwrap_or_default();
+                    let lines: Vec<&str> = exclude_content.lines().collect();
+
+                    // Only add if it doesn't already exist
+                    if !lines.contains(&file_name.as_ref()) {
+                        if !lines.contains(&"# Added by nais-env") {
+                            // Add comment and filename at the end if comment doesn't exist
+                            if let Ok(mut exclude_file) =
+                                std::fs::OpenOptions::new().append(true).open(&exclude_path)
+                            {
+                                use std::io::Write;
+                                let _ = writeln!(exclude_file, "# Added by nais-env");
+                                let _ = writeln!(exclude_file, "{}", file_name);
+                            }
+                        } else {
+                            // If comment exists, insert filename right after it
+                            let mut new_content = String::new();
+                            let mut inserted = false;
+
+                            for line in lines {
+                                new_content.push_str(line);
+                                new_content.push('\n');
+
+                                if line == "# Added by nais-env" && !inserted {
+                                    new_content.push_str(&format!("{}\n", file_name));
+                                    inserted = true;
+                                }
+                            }
+
+                            if let Ok(_) = std::fs::write(&exclude_path, new_content) {
+                                println!(
+                                    "Added {} to local git exclude file (.git/info/exclude)",
+                                    file_name
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+/// Deletes all files listed under the "# Added by nais-env" comment in .git/info/exclude
+///
+/// # Returns
+///
+/// * `io::Result<()>` - Success or error
+pub fn clear_env_files() -> io::Result<()> {
+    // Check if we're in a git repository
+    if let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+    {
+        if output.status.success() {
+            // Get git directory
+            let git_dir = std::process::Command::new("git")
+                .args(["rev-parse", "--git-dir"])
+                .output()
+                .ok()
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|s| s.trim().to_string());
+
+            if let Some(git_dir) = git_dir {
+                let exclude_path = std::path::Path::new(&git_dir).join("info/exclude");
+                if exclude_path.exists() {
+                    // Read the exclude file
+                    let exclude_content = std::fs::read_to_string(&exclude_path)?;
+                    let lines: Vec<&str> = exclude_content.lines().collect();
+
+                    // Find the "# Added by nais-env" comment
+                    let mut files_to_delete: Vec<String> = Vec::new();
+                    let mut in_nais_env_section = false;
+                    let mut updated_content = String::new();
+
+                    // Parse the exclude file
+                    for line in lines {
+                        if line == "# Added by nais-env" {
+                            in_nais_env_section = true;
+                            continue; // Skip this line in the updated content
+                        } else if in_nais_env_section {
+                            if line.is_empty() {
+                                in_nais_env_section = false;
+                                updated_content.push_str("\n");
+                            } else {
+                                files_to_delete.push(line.to_string());
+                                continue; // Skip this line in the updated content
+                            }
+                        } else {
+                            updated_content.push_str(line);
+                            updated_content.push('\n');
+                        }
+                    }
+
+                    // Delete the identified files
+                    for file in &files_to_delete {
+                        let file_path = std::path::Path::new(file);
+                        if file_path.exists() {
+                            std::fs::remove_file(file_path)?;
+                            println!("Deleted env file: {}", file);
+                        }
+                    }
+
+                    // Update the exclude file to remove the entries
+                    if !files_to_delete.is_empty() {
+                        std::fs::write(exclude_path, updated_content)?;
+                        println!(
+                            "Removed {} entries from git exclude file",
+                            files_to_delete.len()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,93 @@
+// Git utility functions
+
+/// Checks if the current directory is inside a git repository
+///
+/// # Returns
+///
+/// * `bool` - True if inside a git repository, false otherwise
+pub fn is_in_git_repo() -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+/// Gets the path to the git directory (.git)
+///
+/// # Returns
+///
+/// * `Option<String>` - Path to the git directory if successful, None otherwise
+pub fn get_git_dir() -> Option<String> {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+}
+
+/// Gets the path to git's exclude file
+///
+/// # Returns
+///
+/// * `Option<std::path::PathBuf>` - Path to the exclude file if in a git repo, None otherwise
+pub fn get_git_exclude_path() -> Option<std::path::PathBuf> {
+    get_git_dir().map(|dir| std::path::Path::new(&dir).join("info/exclude"))
+}
+
+/// Adds a file to git's exclude list
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the file to exclude
+///
+/// # Returns
+///
+/// * `io::Result<()>` - Success or error
+pub fn add_to_git_exclude<P: AsRef<std::path::Path>>(file_path: P) -> std::io::Result<()> {
+    if !is_in_git_repo() {
+        return Ok(());
+    }
+
+    let exclude_path = match get_git_exclude_path() {
+        Some(path) if path.exists() => path,
+        _ => return Ok(()),
+    };
+
+    let file_name = file_path
+        .as_ref()
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy();
+
+    // Read current content
+    let exclude_content = std::fs::read_to_string(&exclude_path)?;
+    let lines: Vec<&str> = exclude_content.lines().collect();
+
+    // Only add if it doesn't already exist
+    if lines.contains(&file_name.as_ref()) {
+        return Ok(());
+    }
+
+    // Prepare for adding the entry
+    let mut exclude_file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&exclude_path)?;
+
+    use std::io::Write;
+
+    // Add the comment if needed
+    if !lines.contains(&"# Added by nais-env") {
+        writeln!(exclude_file, "# Added by nais-env")?;
+    }
+
+    // Add the file name
+    writeln!(exclude_file, "{}", file_name)?;
+    println!(
+        "Added {} to local git exclude file (.git/info/exclude)",
+        file_name
+    );
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::{env, process::Command};
 
 use clap::Parser;
 mod env_file;
+mod git;
 mod kubernetes_client;
 mod nais;
 


### PR DESCRIPTION
Legger til funksjonalitet for å håndtere miljøfiler bedre i forhold til Git-integrasjon. Hovedendringene inkluderer:

1. Automatisk legge til genererte miljøfiler i `.git/info/exclude` for å unngå at sensitive data blir sjekket inn i Git
2. En ny kommando `--clear-files` for å slette alle miljøfiler som tidligere er opprettet av verktøyet
3. Flyttet filhåndteringen fra `main.rs` til `env_file.rs` for bedre kodeorganisering

Dette gjør verktøyet sikrere å bruke siden det nå hjelper brukerne med å unngå å eksponere hemmelige miljøvariabler i Git-historikken. Det gir også en enkel måte å rydde opp i miljøfiler når de ikke lenger trengs.

Closes #5 