### PR TITLE
Legg til tilpasset terminal-prompt i shell med NAIS miljøvariabler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Mulighet for å skrive ut hemmelighetene direkte (når det er trygt å gjøre det)
 - Legger automatisk til genererte filer i `.git/info/exclude` for å unngå at sensitive data sjekkes inn
 - Kan rydde opp og slette alle genererte miljøfiler med `--clear-files`
+- Setter miljøvariabelen `NAIS_ENV_ACTIVE=true` når shell startes med `--shell`
 
 ## Installasjon
 
@@ -36,6 +37,18 @@ nais-env --config path/to/nais.yaml --print
 # Slett alle miljøfiler som er opprettet av nais-env
 nais-env --clear-files
 ```
+
+### Tilpasning av zsh-prompt
+
+For å få en tilpasset prompt i zsh når du bruker `--shell`, kan du legge til følgende i din `.zshrc`:
+
+```zsh
+if [[ -n "$NAIS_ENV_ACTIVE" ]]; then
+  PROMPT="%F{green}[NAIS-ENV:$NAIS_ENV_CONFIG]%f %~ $ "
+fi
+```
+
+Dette vil gi deg en tydelig indikasjon når du jobber i et shell med NAIS-miljøvariabler.
 
 ## Forutsetninger
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,12 @@ fn spawn_interactive_shell(
     env_vars: &std::collections::BTreeMap<String, String>,
     config_file: &str,
 ) -> std::io::Result<()> {
+    // Check if we're already in a NAIS environment shell
+    if env::var("NAIS_ENV_ACTIVE").is_ok() {
+        println!("Already in a NAIS environment shell. Not spawning a new one.");
+        return Ok(());
+    }
+
     let shell = if cfg!(target_os = "windows") {
         String::from("cmd")
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,12 +149,13 @@ fn spawn_interactive_shell(
     command.env("NAIS_ENV_CONFIG", config_file);
 
     if shell_path.contains("bash") {
-        command.env("PS1", "\\[\\e[32m\\][NAIS-ENV]\\[\\e[0m\\] \\w $ ");
-    } else if shell_path.contains("zsh") {
-        command.env("PROMPT", "%F{green}[NAIS-ENV]%f %~ $ ");
+        command.env(
+            "PS1",
+            "\\[\\e[32m\\][NAIS-ENV:$NAIS_ENV_CONFIG]\\[\\e[0m\\] \\w $ ",
+        );
     } else {
         // Fallback for other shells
-        command.env("PS1", "[NAIS-ENV] \\w $ ");
+        command.env("PS1", "[NAIS-ENV:$NAIS_ENV_CONFIG] \\w $ ");
     }
 
     // Execute the command


### PR DESCRIPTION
Gjør det lettere å se når du arbeider i et shell-miljø som kjører med NAIS-konfigurasjon. 

Hovedendringene:
- Setter miljøvariablene `NAIS_ENV_ACTIVE=true` og `NAIS_ENV_CONFIG=[konfig-fil]` når shell startes med `--shell`
- Tilpasser terminal-prompten til å vise at du er i et NAIS-miljø med hvilken konfigurasjonsfil som brukes
- Forhindrer nesting av NAIS-miljø ved å sjekke om du allerede er i et NAIS shell
- Legger til dokumentasjon for hvordan brukere kan tilpasse zsh-prompten ytterligere

Dette gir en tydeligere indikasjon på at du jobber i et miljø med NAIS-variabler og hvilken konfigurasjon som er aktiv, noe som er spesielt nyttig når du jobber med flere prosjekter eller miljøer.

<img width="1226" alt="bilde" src="https://github.com/user-attachments/assets/81e7cf66-0f94-4d0e-bc57-bab33789cfe4" />

Closes #6 
