### PR TITLE
Forbedrer filbanehåndtering for Git-ekskluderte filer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 
 [dependencies]

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -133,11 +133,14 @@ pub fn clear_env_files() -> io::Result<()> {
         return Ok(());
     }
 
-    // Get git exclude path
+    // Get git exclude path and repository root
     let exclude_path = match git::get_git_exclude_path() {
         Some(path) if path.exists() => path,
         _ => return Ok(()),
     };
+
+    // Get repository root directory
+    let repo_root = git::get_repo_root();
 
     // Read the exclude file
     let exclude_content = std::fs::read_to_string(&exclude_path)?;
@@ -169,10 +172,11 @@ pub fn clear_env_files() -> io::Result<()> {
 
     // Delete the identified files
     for file in &files_to_delete {
-        let file_path = std::path::Path::new(file);
+        // Files are relative to repository root now
+        let file_path = std::path::Path::new(&repo_root).join(file);
         if file_path.exists() {
-            std::fs::remove_file(file_path)?;
-            println!("Deleted env file: {}", file);
+            std::fs::remove_file(&file_path)?;
+            println!("Deleted env file: {}", file_path.display());
         }
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -55,18 +55,23 @@ pub fn add_to_git_exclude<P: AsRef<std::path::Path>>(file_path: P) -> std::io::R
         _ => return Ok(()),
     };
 
-    let file_name = file_path
-        .as_ref()
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy();
+    // Get the relative path from repo root
+    let relative_path = match get_relative_path_from_repo_root(&file_path) {
+        Some(path) => path,
+        None => file_path
+            .as_ref()
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string(),
+    };
 
     // Read current content
     let exclude_content = std::fs::read_to_string(&exclude_path)?;
     let lines: Vec<&str> = exclude_content.lines().collect();
 
     // Only add if it doesn't already exist
-    if lines.contains(&file_name.as_ref()) {
+    if lines.contains(&relative_path.as_str()) {
         return Ok(());
     }
 
@@ -82,12 +87,58 @@ pub fn add_to_git_exclude<P: AsRef<std::path::Path>>(file_path: P) -> std::io::R
         writeln!(exclude_file, "# Added by nais-env")?;
     }
 
-    // Add the file name
-    writeln!(exclude_file, "{}", file_name)?;
+    // Add the file path
+    writeln!(exclude_file, "{}", relative_path)?;
     println!(
         "Added {} to local git exclude file (.git/info/exclude)",
-        file_name
+        relative_path
     );
 
     Ok(())
+}
+
+/// Gets the path to the repository root
+///
+/// # Returns
+///
+/// * `String` - Path to the repository root
+pub fn get_repo_root() -> String {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .expect("Failed to execute git command to find repo root");
+
+    if !output.status.success() {
+        panic!("Failed to get git repository root");
+    }
+
+    String::from_utf8(output.stdout)
+        .expect("Invalid UTF-8 in git repo path")
+        .trim()
+        .to_string()
+}
+
+/// Gets the path to a file relative to repository root
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the file
+///
+/// # Returns
+///
+/// * `Option<String>` - Relative path if successful, None otherwise
+fn get_relative_path_from_repo_root<P: AsRef<std::path::Path>>(file_path: P) -> Option<String> {
+    let repo_root = get_repo_root();
+    let repo_root_path = std::path::Path::new(&repo_root);
+
+    let absolute_path = if file_path.as_ref().is_absolute() {
+        file_path.as_ref().to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(file_path.as_ref())
+    };
+
+    absolute_path
+        .strip_prefix(repo_root_path)
+        .ok()
+        .map(|rel_path| rel_path.to_string_lossy().to_string())
 }


### PR DESCRIPTION
Implementerer støtte for relative filbaner i Git-repositorier, slik at filer i undermapper håndteres korrekt ved ekskludering. Legger til funksjoner for å finne repo-roten og konvertere til relative baner, hvilket gjør verktøyet mer robust når brukere arbeider fra forskjellige mapper i prosjektet. Med denne endringen fungerer `--clear-files` kommandoen korrekt uavhengig av hvor i repositoriet den kjøres fra.
