### PR TITLE
Begrens til bare kubernetes context dev-fss og nais-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "nais-env"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-kube = { version = "0.99.0", features = ["runtime", "derive"] }
+kube = { version = "0.99.0", features = ["runtime", "derive", "config"] }
 k8s-openapi = { version = "0.24.0", features = ["latest"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4.5.33", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Legger automatisk til genererte filer i `.git/info/exclude` for å unngå at sensitive data sjekkes inn
 - Kan rydde opp og slette alle genererte miljøfiler med `--clear-files`
 - Setter miljøvariabelen `NAIS_ENV_ACTIVE=true` når shell startes med `--shell`
+- Støtter spesifisering av Kubernetes-kontekst (begrenset til 'nais-dev' og 'dev-fss')
 
 ## Installasjon
 
@@ -36,6 +37,9 @@ nais-env --config path/to/nais.yaml --print
 
 # Slett alle miljøfiler som er opprettet av nais-env
 nais-env --clear-files
+
+# Spesifiser Kubernetes-kontekst (nais-dev eller dev-fss)
+nais-env --config path/to/nais.yaml --context dev-fss
 ```
 
 ### Tilpasning av zsh-prompt


### PR DESCRIPTION
Legger til støtte for å spesifisere hvilken Kubernetes-kontekst som skal brukes, begrenset til 'nais-dev' og 'dev-fss'. 

Endringen introduserer en ny '--context' parameter med standardverdi 'nais-dev', og validerer at bare de to støttede kontekstene kan brukes. Forbedrer også feilhåndteringen ved å returnere mer beskrivende feilmeldinger hvis noe går galt med Kubernetes-operasjonene.

Closes #17 