### PR TITLE
Gjør --config flagget valgfritt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Gjør `--config` flagget valgfritt slik at `--clear-files` kan kjøres uten å måtte spesifisere en konfigurasjonsfil. Forbedrer også feilhåndtering ved opprydding av miljøfiler, med tydeligere feilmeldinger og bedre exit-koder.

Closes #18 
