### PR TITLE
Tab-completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,9 +1059,10 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "clap",
+ "clap_complete",
  "k8s-openapi",
  "kube",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]
@@ -10,3 +10,4 @@ kube = { version = "0.99.0", features = ["runtime", "derive", "config"] }
 k8s-openapi = { version = "0.24.0", features = ["latest"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4.5.33", features = ["derive"] }
+clap_complete = "4.5.1"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,53 @@
 
 TODO: Fix etter github-action
 
+### Tab-completion
+
+Nais-env støtter tab-completion for bash, zsh, fish og PowerShell. Du kan generere completion-skript ved å bruke følgende kommandoer:
+
+#### Bash
+
+```bash
+# Generer og installer completion-skript for gjeldende bruker
+nais-env completion bash > ~/.bash_completion
+
+# På noen systemer må du kanskje laste inn skriptet manuelt
+echo 'source ~/.bash_completion' >> ~/.bashrc
+```
+
+#### Zsh
+
+```zsh
+# Opprett completion-katalog hvis den ikke finnes
+mkdir -p ~/.zsh/completion
+
+# Generer completion-skript
+nais-env completion zsh > ~/.zsh/completion/_nais-env
+
+# Legg til i .zshrc hvis ikke allerede inkludert
+echo 'fpath=(~/.zsh/completion $fpath)' >> ~/.zshrc
+echo 'autoload -U compinit && compinit' >> ~/.zshrc
+```
+
+#### Fish
+
+```fish
+# Generer og installer completion-skript
+nais-env completion fish > ~/.config/fish/completions/nais-env.fish
+```
+
+#### PowerShell
+
+```powershell
+# Generer completion-skript
+nais-env completion powershell > nais-env.ps1
+
+# Legg til i PowerShell-profilen
+echo ". /path/to/nais-env.ps1" >> $PROFILE
+```
+
+Shell må restartes for at tab-completion skal fungere
+
 ## Bruk
 
 ```bash


### PR DESCRIPTION
Implementerer tab-completion støtte for nais-env i flere shell-typer (bash, zsh, fish og PowerShell). Funksjonen gjør det mulig for brukere å generere completion-scripts via en ny `completion` subkommando.

Closes #27 

