### PR TITLE
#33: Legger til støtte for variabler i NAIS-konfigurasjonsfiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "nais-env"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "clap_complete",
  "k8s-openapi",
  "kube",
+ "regex",
  "serde",
  "serde_yaml",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nais-env"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ k8s-openapi = { version = "0.24.0", features = ["latest"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4.5.33", features = ["derive"] }
 clap_complete = "4.5.1"
+regex = "1.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,10 @@ struct Args {
     #[arg(short, long)]
     config: Option<String>,
 
+    /// YAML file containing variables
+    #[arg(short, long)]
+    variables: Option<String>,
+
     /// Print secrets
     #[arg(short, long)]
     print: bool,
@@ -116,8 +120,14 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
-    let nais_config =
-        nais::NaisConfigLoader::new(config_file.clone()).expect("Could not load config file");
+    // Get variable file if provided
+    let variable_file = args.variables;
+
+    let nais_config = match variable_file {
+        Some(var_file) => nais::NaisConfigLoader::new_with_variables(config_file.clone(), var_file),
+        None => nais::NaisConfigLoader::new(config_file.clone()),
+    }
+    .expect("Could not load config file");
 
     let kubernetes_client = kubernetes_client::KubernetesClient::new(
         nais_config.get_namespace(),

--- a/src/nais.rs
+++ b/src/nais.rs
@@ -324,13 +324,13 @@ impl NaisConfigLoader {
 
     /// Creates a new `NaisConfigLoader` instance from a configuration file with variables.
     ///
-    /// This function reads the NAIS configuration from the specified file path and a variables file,
+    /// This function reads the NAIS configuration from the specified file path and a parsed variables object,
     /// validates that the config contains an "Application" kind, and parses it into a
     /// structured representation.
     ///
     /// # Arguments
     /// * `config_path` - The path to the NAIS configuration file
-    /// * `variables_path` - The path to a YAML file containing variables
+    /// * `variables` - A parsed YAML object containing variables for substitution
     ///
     /// # Returns
     /// A `Result` containing either the constructed `NaisConfigLoader` or an error
@@ -339,18 +339,21 @@ impl NaisConfigLoader {
     /// # Errors
     /// This function will return an error if:
     /// * The configuration file cannot be read
-    /// * The variables file cannot be read
     /// * The configuration does not contain "kind: \"Application\""
     /// * The YAML cannot be parsed into the expected structure
     ///
     /// # Example
     /// ```
-    /// let config_loader = NaisConfigLoader::new_with_variables("nais.yaml".to_string(), "vars.yaml".to_string())?;
+    /// let variables = yaml_vars::parse_variables_file("vars.yaml")?;
+    /// let config_loader = NaisConfigLoader::new_with_variables("nais.yaml".to_string(), variables)?;
     /// ```
     pub fn new_with_variables(
         config_path: String,
-        variables_path: String,
+        variables: serde_yaml::Value,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Debug print to show variables were loaded
+        println!("Variables loaded from file: {:?}", variables);
+
         // For now, just use the regular loading method
         // This will be expanded later to handle variable substitution
         Self::new(config_path)

--- a/src/nais.rs
+++ b/src/nais.rs
@@ -322,6 +322,40 @@ impl NaisConfigLoader {
         Ok(NaisConfigLoader { config })
     }
 
+    /// Creates a new `NaisConfigLoader` instance from a configuration file with variables.
+    ///
+    /// This function reads the NAIS configuration from the specified file path and a variables file,
+    /// validates that the config contains an "Application" kind, and parses it into a
+    /// structured representation.
+    ///
+    /// # Arguments
+    /// * `config_path` - The path to the NAIS configuration file
+    /// * `variables_path` - The path to a YAML file containing variables
+    ///
+    /// # Returns
+    /// A `Result` containing either the constructed `NaisConfigLoader` or an error
+    /// if the files cannot be read or parsed.
+    ///
+    /// # Errors
+    /// This function will return an error if:
+    /// * The configuration file cannot be read
+    /// * The variables file cannot be read
+    /// * The configuration does not contain "kind: \"Application\""
+    /// * The YAML cannot be parsed into the expected structure
+    ///
+    /// # Example
+    /// ```
+    /// let config_loader = NaisConfigLoader::new_with_variables("nais.yaml".to_string(), "vars.yaml".to_string())?;
+    /// ```
+    pub fn new_with_variables(
+        config_path: String,
+        variables_path: String,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        // For now, just use the regular loading method
+        // This will be expanded later to handle variable substitution
+        Self::new(config_path)
+    }
+
     /// Retrieves the namespace from the NAIS configuration.
     ///
     /// This method returns the namespace specified in the metadata section

--- a/src/nais.rs
+++ b/src/nais.rs
@@ -322,41 +322,56 @@ impl NaisConfigLoader {
         Ok(NaisConfigLoader { config })
     }
 
-    /// Creates a new `NaisConfigLoader` instance from a configuration file with variables.
+    /// Creates a new `NaisConfigLoader` instance from a configuration file with variable substitution,
+    /// and returns both the loader and the processed template content.
     ///
-    /// This function reads the NAIS configuration from the specified file path and a parsed variables object,
-    /// validates that the config contains an "Application" kind, and parses it into a
-    /// structured representation.
+    /// This function reads the NAIS configuration from the specified file path,
+    /// substitutes variables, parses it into a structured representation,
+    /// and returns the processed template string as well.
     ///
     /// # Arguments
     /// * `config_path` - The path to the NAIS configuration file
-    /// * `variables` - A parsed YAML object containing variables for substitution
+    /// * `variables` - A YAML structure containing variables for substitution
     ///
     /// # Returns
-    /// A `Result` containing either the constructed `NaisConfigLoader` or an error
-    /// if the files cannot be read or parsed.
-    ///
-    /// # Errors
-    /// This function will return an error if:
-    /// * The configuration file cannot be read
-    /// * The configuration does not contain "kind: \"Application\""
-    /// * The YAML cannot be parsed into the expected structure
+    /// A `Result` containing either a tuple of the constructed `NaisConfigLoader` and the
+    /// processed template content, or an error if the file cannot be read or parsed.
     ///
     /// # Example
     /// ```
     /// let variables = yaml_vars::parse_variables_file("vars.yaml")?;
-    /// let config_loader = NaisConfigLoader::new_with_variables("nais.yaml".to_string(), variables)?;
+    /// let (config_loader, processed_template) = NaisConfigLoader::new_with_variables_and_template(
+    ///     "nais.yaml".to_string(),
+    ///     variables
+    /// )?;
     /// ```
-    pub fn new_with_variables(
+    pub fn new_with_variables_and_template(
         config_path: String,
         variables: serde_yaml::Value,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        // Debug print to show variables were loaded
-        println!("Variables loaded from file: {:?}", variables);
+    ) -> Result<(Self, String), Box<dyn std::error::Error>> {
+        let content = match std::fs::read_to_string(&config_path) {
+            Ok(content) => content,
+            Err(e) => {
+                return Err(format!("Failed to read config file {}: {}", config_path, e).into());
+            }
+        };
 
-        // For now, just use the regular loading method
-        // This will be expanded later to handle variable substitution
-        Self::new(config_path)
+        // Substitute variables in the content using template syntax
+        let processed_content = crate::yaml_vars::substitute_variables(&content, &variables);
+
+        if !processed_content.contains("kind: \"Application\"")
+            && !processed_content.contains("kind: \'Application\'")
+            && !processed_content.contains("kind: Application")
+        {
+            return Err("Expected kind: Application".into());
+        }
+
+        let config: NaisConfig = match serde_yaml::from_str(&processed_content) {
+            Ok(config) => config,
+            Err(e) => panic!("Failed to parse config as YAML: {}", e),
+        };
+
+        Ok((NaisConfigLoader { config }, processed_content))
     }
 
     /// Retrieves the namespace from the NAIS configuration.

--- a/src/yaml_vars.rs
+++ b/src/yaml_vars.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use serde_yaml::Value;
 use std::fs::File;
 use std::io::Read;
@@ -35,4 +36,91 @@ pub fn parse_variables_file<P: AsRef<Path>>(
     let variables: Value = serde_yaml::from_str(&content)?;
 
     Ok(variables)
+}
+
+/// Gets a value from a YAML structure using a dotted path notation
+///
+/// # Arguments
+/// * `yaml_value` - The YAML value to extract from
+/// * `path` - The dot-separated path to the desired value (e.g., "app.name")
+///
+/// # Returns
+/// A string representation of the value or empty string if not found
+fn get_value_at_path(yaml_value: &Value, path: &str) -> String {
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current = yaml_value;
+
+    // Navigate through the nested structure
+    for &part in &parts {
+        match current {
+            Value::Mapping(map) => {
+                // Try with string key
+                let key = Value::String(part.to_string());
+                if let Some(value) = map.get(&key) {
+                    current = value;
+                    continue;
+                }
+
+                // Key not found
+                return String::new();
+            }
+            _ => return String::new(), // Not a mapping, can't navigate further
+        }
+    }
+
+    // Convert the final value to a string
+    match current {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Null => String::new(),
+        Value::Sequence(seq) => {
+            let items: Vec<String> = seq
+                .iter()
+                .map(|v| match v {
+                    Value::String(s) => s.clone(),
+                    Value::Number(n) => n.to_string(),
+                    Value::Bool(b) => b.to_string(),
+                    _ => format!("{:?}", v),
+                })
+                .collect();
+            items.join(",")
+        }
+        _ => format!("{:?}", current),
+    }
+}
+
+/// Substitutes variables in a string using the format {{ variable.path }}
+///
+/// # Arguments
+/// * `content` - The string content to perform substitution on
+/// * `variables` - The YAML value containing all variables
+///
+/// # Returns
+/// A new string with all variables substituted
+///
+/// # Example
+/// ```
+/// let content = "apiVersion: \"nais.io/v1alpha1\"\nkind: \"Application\"\nmetadata:\n  name: \"{{ app.name }}\"";
+/// let variables = parse_variables_file("vars.yaml")?;
+/// let result = substitute_variables(content, &variables);
+/// ```
+pub fn substitute_variables(content: &str, variables: &Value) -> String {
+    // Regex to match {{ var.path }} patterns, both quoted and unquoted
+    let re = Regex::new(r#"(?:"?\{\{\s*([^{}]+?)\s*\}\}"?|\{\{\s*([^{}]+?)\s*\}\})"#).unwrap();
+
+    let result = re.replace_all(content, |caps: &regex::Captures| {
+        // Check which capture group matched (with or without quotes)
+        let path = if let Some(m) = caps.get(1) {
+            m.as_str().trim()
+        } else if let Some(m) = caps.get(2) {
+            m.as_str().trim()
+        } else {
+            return String::new();
+        };
+
+        get_value_at_path(variables, path)
+    });
+
+    result.to_string()
 }

--- a/src/yaml_vars.rs
+++ b/src/yaml_vars.rs
@@ -1,0 +1,38 @@
+use serde_yaml::Value;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+/// Parses a YAML file containing variables and returns the parsed YAML value.
+///
+/// The YAML file should contain variables that can be used for substitution
+/// in configuration files.
+///
+/// # Arguments
+/// * `file_path` - Path to the YAML file containing variables
+///
+/// # Returns
+/// A result containing the parsed YAML structure or an error if parsing fails
+///
+/// # Errors
+/// This function will return an error if:
+/// * The file cannot be read
+/// * The YAML cannot be parsed
+///
+/// # Example
+/// ```
+/// let variables = parse_variables_file("vars.yaml")?;
+/// ```
+pub fn parse_variables_file<P: AsRef<Path>>(
+    file_path: P,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    // Read the file contents
+    let mut file = File::open(file_path.as_ref())?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+
+    // Parse YAML content as a Value
+    let variables: Value = serde_yaml::from_str(&content)?;
+
+    Ok(variables)
+}


### PR DESCRIPTION
Implementerer variabelsubstitusjon i NAIS-konfigurasjonsfiler ved bruk av `{{ variabel.sti }}` syntaks. Legger til to nye kommandolinjeargumenter: `--variables` for å spesifisere en YAML-fil med variabler og `--print-template` for å vise den behandlede malen.
